### PR TITLE
Run ci on julia LTS and current stable release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         version:
           - '1.6'
+          - '1.7'
           # - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.5'
+          version: '1.6'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.3'
-          - '1.5'
           - '1.6'
           # - 'nightly'
         os:

--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.4.2]
+        julia-version: '1.6'
         julia-arch: [x86]
         os: [ubuntu-latest]
     steps:


### PR DESCRIPTION
I've updated GitHub Actions. (1.6 is the new LTS!)