### PR TITLE
use `import .Makie`

### DIFF
--- a/src/visualize.jl
+++ b/src/visualize.jl
@@ -1,4 +1,4 @@
-import Makie
+import .Makie
 import GeometryBasics
 export visualize
 


### PR DESCRIPTION
This PR adopts `import .Makie` to suppress the warning for the first call of Flux3D.

```julia
julia> using Flux3D
┌ Warning: Package Flux3D does not have Makie in its dependencies:
│ - If you have Flux3D checked out for development and have
│   added Makie as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with Flux3D
│ Loading Makie into Flux3D from project dependency, future warnings for Flux3D are suppressed.
└ @ nothing nothing:984
```

This modification is preferred according to [Requires.jl/README.md](https://github.com/JuliaPackaging/Requires.jl#requiresjl) 

![image](https://user-images.githubusercontent.com/16760547/149537318-2b1f1bc9-861c-4e7b-aec7-48efe1fb41a6.png)
